### PR TITLE
Add enchantable miner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [ '**' ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -33,3 +34,8 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bedrockores-${{ matrix.os }}
+          path: build/libs/*.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ tasks {
         val properties = mapOf(
                 "version" to modVersion,
                 "minecraftVersion" to minecraftVersion,
-                "loaderVersion" to forgeVersion.split(".").first(),
+                "loaderVersion" to forgeVersion.substringBefore('.'),
                 "forgeVersion" to forgeVersion
         )
         inputs.properties(properties)

--- a/src/main/java/li/cil/bedrockores/common/block/Blocks.java
+++ b/src/main/java/li/cil/bedrockores/common/block/Blocks.java
@@ -14,6 +14,7 @@ public final class Blocks {
 
     public static final RegistryObject<BedrockOreBlock> BEDROCK_ORE = BLOCKS.register("bedrock_ore", BedrockOreBlock::new);
     public static final RegistryObject<BedrockMinerBlock> BEDROCK_MINER = BLOCKS.register("bedrock_miner", BedrockMinerBlock::new);
+    public static final RegistryObject<EnchantedMinerBlock> ENCHANTED_BEDROCK_MINER = BLOCKS.register("enchanted_bedrock_miner", EnchantedMinerBlock::new);
 
     // --------------------------------------------------------------------- //
 

--- a/src/main/java/li/cil/bedrockores/common/block/EnchantedMinerBlock.java
+++ b/src/main/java/li/cil/bedrockores/common/block/EnchantedMinerBlock.java
@@ -1,0 +1,106 @@
+package li.cil.bedrockores.common.block;
+
+import li.cil.bedrockores.common.block.entity.EnchantedMinerBlockEntity;
+import li.cil.bedrockores.common.block.entity.BlockEntities;
+import li.cil.bedrockores.common.config.Constants;
+import li.cil.bedrockores.common.config.Settings;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.Containers;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.MapColor;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class EnchantedMinerBlock extends BaseEntityBlock {
+    public EnchantedMinerBlock() {
+        super(Properties.of()
+                .mapColor(MapColor.METAL)
+                .strength(5, 10)
+                .sound(SoundType.METAL));
+    }
+
+    // --------------------------------------------------------------------- //
+    // BaseEntityBlock
+
+    @Override
+    public BlockEntity newBlockEntity(final BlockPos pos, final BlockState state) {
+        return BlockEntities.ENCHANTED_MINER.get().create(pos, state);
+    }
+
+    @Override
+    public void setPlacedBy(final Level level, final BlockPos pos, final BlockState state,
+                            @Nullable final net.minecraft.world.entity.LivingEntity placer, final ItemStack stack) {
+        super.setPlacedBy(level, pos, state, placer, stack);
+        if (level.getBlockEntity(pos) instanceof EnchantedMinerBlockEntity miner) {
+            miner.setEnchantments(stack);
+        }
+    }
+
+    @Nullable
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(final Level level, final BlockState state, final BlockEntityType<T> type) {
+        if (level.isClientSide()) {
+            return createTickerHelper(type, BlockEntities.ENCHANTED_MINER.get(), EnchantedMinerBlockEntity::clientTick);
+        } else {
+            return createTickerHelper(type, BlockEntities.ENCHANTED_MINER.get(), EnchantedMinerBlockEntity::serverTick);
+        }
+    }
+
+    @Override
+    public RenderShape getRenderShape(final BlockState state) {
+        return RenderShape.MODEL;
+    }
+
+    // --------------------------------------------------------------------- //
+    // Block
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean hasAnalogOutputSignal(final BlockState state) {
+        return true;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public int getAnalogOutputSignal(final BlockState blockState, final Level level, final BlockPos pos) {
+        if (level.getBlockEntity(pos) instanceof EnchantedMinerBlockEntity miner) {
+            return miner.isWorking() ? 15 : 0;
+        } else {
+            return super.getAnalogOutputSignal(blockState, level, pos);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onRemove(final BlockState oldState, final Level level, final BlockPos pos, final BlockState newState, final boolean movedByPiston) {
+        if (level.getBlockEntity(pos) instanceof EnchantedMinerBlockEntity miner) {
+            miner.getCapability(ForgeCapabilities.ITEM_HANDLER).ifPresent(itemHandler -> {
+                for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+                    Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), itemHandler.getStackInSlot(slot));
+                }
+            });
+        }
+        super.onRemove(oldState, level, pos, newState, movedByPiston);
+    }
+
+    @Override
+    public void appendHoverText(final ItemStack stack, @Nullable final BlockGetter level, final List<Component> tooltip, final TooltipFlag flags) {
+        super.appendHoverText(stack, level, tooltip, flags);
+        final var edgeLength = (Settings.minerAreaRadius.get() - 1) * 2 + 1;
+        final var layers = Settings.minerAreaLayers.get();
+        tooltip.add(Component.translatable(Constants.TOOLTIP_BEDROCK_MINER, edgeLength, layers, edgeLength).withStyle(ChatFormatting.GRAY));
+    }
+}

--- a/src/main/java/li/cil/bedrockores/common/block/entity/BlockEntities.java
+++ b/src/main/java/li/cil/bedrockores/common/block/entity/BlockEntities.java
@@ -17,6 +17,7 @@ public final class BlockEntities {
 
     public static final RegistryObject<BlockEntityType<BedrockOreBlockEntity>> BEDROCK_ORE = register(Blocks.BEDROCK_ORE, BedrockOreBlockEntity::new);
     public static final RegistryObject<BlockEntityType<BedrockOreMinerBlockEntity>> MINER = register(Blocks.BEDROCK_MINER, BedrockOreMinerBlockEntity::new);
+    public static final RegistryObject<BlockEntityType<EnchantedMinerBlockEntity>> ENCHANTED_MINER = register(Blocks.ENCHANTED_BEDROCK_MINER, EnchantedMinerBlockEntity::new);
 
     // --------------------------------------------------------------------- //
 

--- a/src/main/java/li/cil/bedrockores/common/block/entity/EnchantedMinerBlockEntity.java
+++ b/src/main/java/li/cil/bedrockores/common/block/entity/EnchantedMinerBlockEntity.java
@@ -1,0 +1,597 @@
+package li.cil.bedrockores.common.block.entity;
+
+import li.cil.bedrockores.common.config.Constants;
+import li.cil.bedrockores.common.config.Settings;
+import li.cil.bedrockores.common.sound.Sounds;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.energy.EnergyStorage;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.TemporalAmount;
+import java.util.OptionalInt;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.partitioningBy;
+
+public final class EnchantedMinerBlockEntity extends BlockEntityWithInfo {
+    // --------------------------------------------------------------------- //
+    // Persisted data
+
+    private final FuelItemHandler fuelInventory = new FuelItemHandler();
+    private final OutputItemHandler outputInventory = new OutputItemHandler();
+    private final EnergyStorageMiner energyStorage = new EnergyStorageMiner();
+
+    private int remainingBurnTime = 0;
+    private int extractionCooldown = -1;
+    private int transferCooldown = 20;
+
+    // --------------------------------------------------------------------- //
+    // Computed data
+
+    private static final String TAG_FUEL_INVENTORY = "input";
+    private static final String TAG_OUTPUT_INVENTORY = "output";
+    private static final String TAG_ENERGY_STORAGE = "energyStorage";
+    private static final String TAG_REMAINING_BURN_TIME = "burnTime";
+    private static final String TAG_EXTRACTION_COOLDOWN = "extractionCooldown";
+    private static final String TAG_WORKING = "working";
+    private static final String TAG_FORTUNE = "fortune";
+    private static final String TAG_EFFICIENCY = "efficiency";
+
+    private static final TemporalAmount SEND_WORKING_STATE_DELAY = Duration.ofSeconds(1);
+
+    private static final int SLOT_FUEL_COUNT = 1;
+    private static final int SLOT_OUTPUT_COUNT = 6;
+
+    private static final int RF_PER_BURN_TIME = 10;
+
+    private static final int SOUND_INTERVAL = 30; // in ticks
+
+    private int fortuneLevel;
+    private int efficiencyLevel;
+
+    @Nullable
+    private BedrockOreBlockEntity currentOre;
+    private boolean hasNoMoreOres;
+
+    // We delay sending the working state to clients a little to avoid small
+    // hiccups causing unnecessary update packets being sent.
+    private boolean isWorkingServer, isWorkingClient;
+    @Nullable
+    private Instant sendUpdateTagAfter;
+
+    private int soundCooldown;
+
+    // --------------------------------------------------------------------- //
+
+    public EnchantedMinerBlockEntity(final BlockPos pos, final BlockState state) {
+        super(BlockEntities.ENCHANTED_MINER.get(), pos, state);
+    }
+
+    public void setEnchantments(final ItemStack stack) {
+        fortuneLevel = net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_FORTUNE, stack);
+        efficiencyLevel = net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_EFFICIENCY, stack);
+        setChanged();
+    }
+
+    // --------------------------------------------------------------------- //
+
+    public boolean isWorking() {
+        return isWorkingServer;
+    }
+
+    // --------------------------------------------------------------------- //
+
+    public static void clientTick(final Level ignoredLevel, final BlockPos ignoredPos, final BlockState ignoredState, final EnchantedMinerBlockEntity miner) {
+        miner.clientTick();
+    }
+
+    public static void serverTick(final Level ignoredLevel, final BlockPos ignoredPos, final BlockState ignoredState, final EnchantedMinerBlockEntity miner) {
+        miner.serverTick();
+    }
+
+    private void clientTick() {
+        updateEffects();
+    }
+
+    private void serverTick() {
+        flushOutput();
+        if (!hasAvailableOutputSlot()) {
+            setWorking(false);
+            return;
+        }
+
+        findBedrockOre();
+        if (!hasAvailableInputOre()) {
+            setWorking(false);
+            return;
+        }
+
+        if (getInternalPowerEfficiency() > 0 || getExternalPowerEfficiency() > 0) {
+            updateBurnTime();
+            if (!hasRemainingBurnTime()) {
+                setWorking(false);
+                return;
+            }
+        }
+
+        extractBedrockOre();
+        setWorking(true);
+    }
+
+    // --------------------------------------------------------------------- //
+    // BlockEntityWithInfo
+
+    @Override
+    protected Component buildInfo() {
+        final var ores = findBedrockOres().
+                map(BedrockOreBlockEntity::getAmount).
+                collect(partitioningBy(OptionalInt::isPresent));
+
+        // If there are any infinite ore spawns within range, we can consider this miner to have infinite yield.
+        final var infiniteOres = ores.get(false);
+        if (!infiniteOres.isEmpty()) {
+            return Component.translatable(Constants.GUI_EXPECTED_YIELD, Component.translatable(Constants.GUI_INFINITE));
+        }
+
+        final var finiteOres = ores.get(true);
+        @SuppressWarnings("OptionalGetWithoutIsPresent") final int yield = finiteOres.stream().
+                map(OptionalInt::getAsInt).
+                reduce(Integer::sum).
+                orElse(0);
+        if (yield > 0) {
+            return Component.translatable(Constants.GUI_EXPECTED_YIELD, yield);
+        } else {
+            return Component.translatable(Constants.GUI_EXHAUSTED);
+        }
+    }
+
+    // --------------------------------------------------------------------- //
+    // BlockEntity
+
+    @Override
+    public Packet<ClientGamePacketListener> getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
+
+    @Override
+    public CompoundTag getUpdateTag() {
+        final var tag = new CompoundTag();
+        tag.putBoolean(TAG_WORKING, isWorkingServer);
+        return tag;
+    }
+
+    @Override
+    protected void saveAdditional(final CompoundTag tag) {
+        super.saveAdditional(tag);
+
+        tag.put(TAG_FUEL_INVENTORY, fuelInventory.serializeNBT());
+        tag.put(TAG_OUTPUT_INVENTORY, outputInventory.serializeNBT());
+        tag.putInt(TAG_ENERGY_STORAGE, energyStorage.getEnergyStored());
+        tag.putInt(TAG_REMAINING_BURN_TIME, remainingBurnTime);
+        tag.putInt(TAG_EXTRACTION_COOLDOWN, extractionCooldown);
+        tag.putInt(TAG_FORTUNE, fortuneLevel);
+        tag.putInt(TAG_EFFICIENCY, efficiencyLevel);
+    }
+
+    @Override
+    public void load(final CompoundTag tag) {
+        super.load(tag);
+
+        fuelInventory.deserializeNBT(tag.getCompound(TAG_FUEL_INVENTORY));
+        outputInventory.deserializeNBT(tag.getCompound(TAG_OUTPUT_INVENTORY));
+        energyStorage.setEnergy(tag.getInt(TAG_ENERGY_STORAGE));
+        remainingBurnTime = tag.getInt(TAG_REMAINING_BURN_TIME);
+        extractionCooldown = tag.getInt(TAG_EXTRACTION_COOLDOWN);
+        fortuneLevel = tag.getInt(TAG_FORTUNE);
+        efficiencyLevel = tag.getInt(TAG_EFFICIENCY);
+        isWorkingClient = tag.getBoolean(TAG_WORKING);
+    }
+
+    // --------------------------------------------------------------------- //
+    // ICapabilityProvider
+
+    @Override
+    public @NotNull <T> LazyOptional<T> getCapability(@NotNull final Capability<T> cap, @org.jetbrains.annotations.Nullable final Direction side) {
+        if (side != null) {
+            if (cap == ForgeCapabilities.ITEM_HANDLER) {
+                if (side == Direction.UP) {
+                    return LazyOptional.of(() -> outputInventory).cast();
+                }
+                if (side.getAxis().isHorizontal() && getInternalPowerEfficiency() > 0) {
+                    return LazyOptional.of(() -> fuelInventory).cast();
+                }
+            } else if (cap == ForgeCapabilities.ENERGY) {
+                if (side.getAxis().isHorizontal() && getExternalPowerEfficiency() > 0) {
+                    return LazyOptional.of(() -> energyStorage).cast();
+                }
+            }
+        }
+        return super.getCapability(cap, side);
+    }
+
+    // --------------------------------------------------------------------- //
+
+    private void updateEffects() {
+        if (!isWorkingClient) {
+            return;
+        }
+
+        if (soundCooldown > 0) {
+            soundCooldown--;
+        }
+
+        final var level = getLevel();
+        if (level == null) {
+            return;
+        }
+
+        if (soundCooldown <= 0) {
+            soundCooldown = SOUND_INTERVAL;
+            final var player = Minecraft.getInstance().player;
+            if (player != null) {
+                final var pos = Vec3.atCenterOf(getBlockPos());
+                final var volume = 1.0f;
+                final var range = Sounds.MINER.get().getRange(volume);
+                if (player.distanceToSqr(pos) < range * range) {
+                    level.playLocalSound(pos.x(), pos.y(), pos.z(), Sounds.MINER.get(), SoundSource.BLOCKS, volume, 1, false);
+                }
+            }
+        }
+
+        final var rng = level.random;
+        for (final var facing : Direction.Plane.HORIZONTAL) {
+            final var direction = new Vec3(facing.step());
+
+            final var up = new Vec3(0, 1, 0);
+            final var right = direction.cross(up);
+            final var dx = (rng.nextFloat() - 0.5f) * 0.3f;
+            final var dy = (rng.nextFloat() - 0.5f) * 0.3f;
+
+            final var origin = Vec3.atCenterOf(getBlockPos()).
+                    add(direction.scale(0.5)).
+                    add(right.scale(dx)).
+                    add(up.scale(dy));
+            final var velocity = direction.scale(0.05);
+
+            level.addParticle(ParticleTypes.SMOKE, origin.x, origin.y, origin.z, velocity.x, velocity.y, velocity.z);
+        }
+    }
+
+    private void flushOutput() {
+        final var level = getLevel();
+        if (level == null) {
+            return;
+        }
+
+        final var outputSlot = findFirstNonEmptyOutputSlot();
+        if (outputSlot < 0) {
+            return;
+        }
+
+        if (transferCooldown > 0) {
+            --transferCooldown;
+        }
+        if (transferCooldown > 0) {
+            return;
+        }
+
+        LazyOptional<IItemHandler> optionalItemhandler = LazyOptional.empty();
+
+        final var blockPos = getBlockPos().above();
+        final var blockEntity = level.getBlockEntity(blockPos);
+        if (blockEntity != null) {
+            optionalItemhandler = blockEntity.getCapability(ForgeCapabilities.ITEM_HANDLER, Direction.DOWN);
+        }
+
+        if (!optionalItemhandler.isPresent()) {
+            final var entities = level.getEntities((Entity) null, new AABB(blockPos), entity -> entity.getCapability(ForgeCapabilities.ITEM_HANDLER, Direction.DOWN).isPresent());
+            if (!entities.isEmpty()) {
+                final Entity entity = entities.get(level.random.nextInt(entities.size()));
+                optionalItemhandler = entity.getCapability(ForgeCapabilities.ITEM_HANDLER, Direction.DOWN);
+            }
+        }
+
+        if (!optionalItemhandler.isPresent()) {
+            transferCooldown = 20;
+            return;
+        }
+
+        final var stack = outputInventory.getStackInSlot(outputSlot);
+        if (optionalItemhandler.isPresent()) {
+            final var itemHandler = optionalItemhandler.orElseThrow(AssertionError::new);
+            final ItemStack remainder = ItemHandlerHelper.insertItem(itemHandler, stack.copy(), false);
+            if (!ItemStack.matches(stack, remainder)) {
+                outputInventory.setStackInSlot(outputSlot, remainder);
+                setChanged();
+            }
+        }
+
+        transferCooldown = 10;
+    }
+
+    private int findFirstNonEmptyOutputSlot() {
+        for (var slot = 0; slot < outputInventory.getSlots(); ++slot) {
+            final var stack = outputInventory.getStackInSlot(slot);
+            if (!stack.isEmpty()) {
+                return slot;
+            }
+        }
+        return -1;
+    }
+
+    private boolean hasAvailableOutputSlot() {
+        for (var slot = 0; slot < outputInventory.getSlots(); ++slot) {
+            final var stack = outputInventory.getStackInSlot(slot);
+            if (stack.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void findBedrockOre() {
+        if (hasNoMoreOres) {
+            return;
+        }
+
+        if (currentOre == null || currentOre.isRemoved() || currentOre.isEmpty()) {
+            currentOre = findBedrockOres().findFirst().orElse(null);
+            if (currentOre == null) {
+                hasNoMoreOres = true;
+                setWorking(false);
+            }
+        }
+    }
+
+    private boolean hasAvailableInputOre() {
+        return currentOre != null;
+    }
+
+    private void updateBurnTime() {
+        if (remainingBurnTime > 0) {
+            --remainingBurnTime;
+        }
+
+        if (remainingBurnTime <= 0 && getExternalPowerEfficiency() > 0) {
+            final var energyBurnTime = energyStorage.consumeEnergyForBurnTime();
+            final var scaledBurnTime = Mth.ceil(energyBurnTime * getExternalPowerEfficiency());
+            if (scaledBurnTime > 0) {
+                remainingBurnTime = scaledBurnTime;
+                setChanged();
+            }
+        }
+
+        if (remainingBurnTime <= 0 && getInternalPowerEfficiency() > 0) {
+            final var stack = fuelInventory.extractItem(0, Integer.MAX_VALUE, false);
+            final var stackBurnTime = ForgeHooks.getBurnTime(stack, RecipeType.SMELTING);
+            final var scaledBurnTime = Mth.ceil(stackBurnTime * getInternalPowerEfficiency());
+            if (scaledBurnTime > 0) {
+                remainingBurnTime = scaledBurnTime;
+                setChanged();
+            }
+        }
+    }
+
+    private boolean hasRemainingBurnTime() {
+        return remainingBurnTime > 0;
+    }
+
+    private void extractBedrockOre() {
+        final var bedrockOre = requireNonNull(currentOre);
+
+        if (extractionCooldown > 0) {
+            extractionCooldown--;
+            return;
+        }
+
+        final var level = requireNonNull(getLevel());
+        final var pos = bedrockOre.getBlockPos();
+
+        final var oreState = bedrockOre.getOreBlockState();
+        final var tool = new ItemStack(Items.DIAMOND_PICKAXE);
+        if (fortuneLevel > 0) {
+            tool.enchant(Enchantments.BLOCK_FORTUNE, fortuneLevel);
+        }
+
+        var drops = Block.getDrops(oreState, (ServerLevel) level, pos, null, null, tool);
+        for (final var drop : drops) {
+            ItemHandlerHelper.insertItem(outputInventory, drop.copy(), false);
+        }
+        bedrockOre.extract();
+        setChanged();
+
+        extractionCooldown = Math.max(1, Settings.minerExtractionCooldown.get() / (1 + efficiencyLevel));
+
+        final var soundType = oreState.getSoundType(level, pos, null);
+        final var blockCenter = Vec3.atCenterOf(pos);
+        level.playSound(null, blockCenter.x(), blockCenter.y(), blockCenter.z(), soundType.getBreakSound(), SoundSource.BLOCKS, soundType.getVolume(), soundType.getPitch());
+    }
+
+    private Stream<BedrockOreBlockEntity> findBedrockOres() {
+        return StreamSupport.stream(new ScanAreaSpliterator(), false);
+    }
+
+    private void setWorking(final boolean value) {
+        isWorkingServer = value;
+
+        if (isWorkingServer == isWorkingClient) {
+            sendUpdateTagAfter = null;
+        } else if (sendUpdateTagAfter == null) {
+            sendUpdateTagAfter = Instant.now().plus(SEND_WORKING_STATE_DELAY);
+        }
+
+        if (sendUpdateTagAfter != null && Instant.now().isAfter(sendUpdateTagAfter)) {
+            sendUpdateTagAfter = null;
+            isWorkingClient = isWorkingServer;
+            requireNonNull(getLevel()).sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_ALL);
+        }
+    }
+
+    private static double getInternalPowerEfficiency() {
+        return Settings.minerEfficiency.get() * Settings.minerEfficiencyInternalPower.get();
+    }
+
+    private static double getExternalPowerEfficiency() {
+        return Settings.minerEfficiency.get() * Settings.minerEfficiencyExternalPower.get();
+    }
+
+    private static int computeNumberOfBlocksInArea(final int efficiencyLevel) {
+        final int radius = Settings.minerAreaRadius.get() - 1 + efficiencyLevel;
+        final int layers = Settings.minerAreaLayers.get() + efficiencyLevel;
+        return (radius * 2 + 1) * (radius * 2 + 1) * layers;
+    }
+
+    // --------------------------------------------------------------------- //
+
+    private final class ScanAreaSpliterator extends Spliterators.AbstractSpliterator<BedrockOreBlockEntity> {
+        private int x, y, z;
+
+        ScanAreaSpliterator() {
+            super(computeNumberOfBlocksInArea(EnchantedMinerBlockEntity.this.efficiencyLevel), ORDERED | DISTINCT | SIZED | NONNULL | IMMUTABLE | SUBSIZED);
+            this.x = -radius();
+            this.z = -radius();
+            this.y = 0;
+        }
+
+        @Override
+        public boolean tryAdvance(final Consumer<? super BedrockOreBlockEntity> action) {
+            final var scanLevel = requireNonNull(getLevel());
+            while (y < layers()) {
+                final var pos = getBlockPos().below().offset(x, -y, z);
+
+                x++;
+                if (x > radius()) {
+                    x = -radius();
+                    z++;
+                    if (z > radius()) {
+                        z = -radius();
+                        y++;
+                    }
+                }
+
+                final var tileEntity = scanLevel.getBlockEntity(pos);
+                if (tileEntity instanceof BedrockOreBlockEntity bedrockOre) {
+                    action.accept(bedrockOre);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private int radius() {
+            return Settings.minerAreaRadius.get() - 1 + efficiencyLevel;
+        }
+
+        private int layers() {
+            return Settings.minerAreaLayers.get() + efficiencyLevel;
+        }
+
+    }
+
+    private final class FuelItemHandler extends ItemStackHandler {
+        FuelItemHandler() {
+            super(SLOT_FUEL_COUNT);
+        }
+
+        @Nonnull
+        @Override
+        public ItemStack insertItem(final int slot, @Nonnull final ItemStack stack, final boolean simulate) {
+            if (getInternalPowerEfficiency() <= 0) {
+                return stack;
+            }
+
+            final int stackBurnTime = ForgeHooks.getBurnTime(stack, RecipeType.SMELTING);
+            final var scaledBurnTime = Mth.ceil(stackBurnTime * getInternalPowerEfficiency());
+            if (scaledBurnTime <= 0) {
+                return stack;
+            }
+
+            return super.insertItem(slot, stack, simulate);
+        }
+
+        @Override
+        public int getSlotLimit(final int slot) {
+            return 1;
+        }
+
+        @Override
+        protected void onContentsChanged(final int slot) {
+            super.onContentsChanged(slot);
+            setChanged();
+        }
+    }
+
+    private final class OutputItemHandler extends ItemStackHandler {
+        OutputItemHandler() {
+            super(SLOT_OUTPUT_COUNT);
+        }
+
+        @Override
+        public int getSlotLimit(final int slot) {
+            return 1;
+        }
+
+        @Override
+        protected void onContentsChanged(final int slot) {
+            super.onContentsChanged(slot);
+            setChanged();
+        }
+    }
+
+    private static final class EnergyStorageMiner extends EnergyStorage {
+        public EnergyStorageMiner() {
+            super(computeCapacity(), computeCapacity(), 0);
+        }
+
+        public void setEnergy(final int value) {
+            this.energy = value;
+        }
+
+        public int consumeEnergyForBurnTime() {
+            final var availableBurnTime = energy / RF_PER_BURN_TIME;
+            final var usedEnergy = Math.min(energy, availableBurnTime * RF_PER_BURN_TIME);
+            energy -= usedEnergy;
+            return availableBurnTime;
+        }
+
+        private static int computeCapacity() {
+            return Math.max(100, Mth.ceil(ForgeHooks.getBurnTime(new ItemStack(Items.COAL), RecipeType.SMELTING) / (RF_PER_BURN_TIME * getExternalPowerEfficiency())));
+        }
+    }
+}

--- a/src/main/java/li/cil/bedrockores/common/item/EnchantedMinerItem.java
+++ b/src/main/java/li/cil/bedrockores/common/item/EnchantedMinerItem.java
@@ -1,0 +1,34 @@
+package li.cil.bedrockores.common.item;
+
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.block.Block;
+
+public final class EnchantedMinerItem extends BlockItem {
+    public EnchantedMinerItem(Block block, Item.Properties properties) {
+        super(block, properties);
+    }
+
+    @Override
+    public boolean isEnchantable(ItemStack stack) {
+        return true;
+    }
+
+    @Override
+    public int getEnchantmentValue() {
+        return 10;
+    }
+
+    @Override
+    public boolean isBookEnchantable(ItemStack stack, ItemStack book) {
+        return true;
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment) {
+        return enchantment == Enchantments.BLOCK_FORTUNE || enchantment == Enchantments.BLOCK_EFFICIENCY;
+    }
+}

--- a/src/main/java/li/cil/bedrockores/common/item/Items.java
+++ b/src/main/java/li/cil/bedrockores/common/item/Items.java
@@ -15,6 +15,7 @@ public final class Items {
     // --------------------------------------------------------------------- //
 
     public static final RegistryObject<Item> BEDROCK_MINER = ITEMS.register(Blocks.BEDROCK_MINER.getId().getPath(), () -> new BlockItem(Blocks.BEDROCK_MINER.get(), new Item.Properties()));
+    public static final RegistryObject<Item> ENCHANTED_MINER = ITEMS.register(Blocks.ENCHANTED_BEDROCK_MINER.getId().getPath(), () -> new EnchantedMinerItem(Blocks.ENCHANTED_BEDROCK_MINER.get(), new Item.Properties()));
 
     // --------------------------------------------------------------------- //
 

--- a/src/main/java/li/cil/bedrockores/common/item/ModCreativeModTabs.java
+++ b/src/main/java/li/cil/bedrockores/common/item/ModCreativeModTabs.java
@@ -13,6 +13,7 @@ public final class ModCreativeModTabs {
     public static void handleCreativeTabEvent(final BuildCreativeModeTabContentsEvent event) {
         if (event.getTabKey() == CreativeModeTabs.FUNCTIONAL_BLOCKS) {
             event.accept(Items.BEDROCK_MINER.get());
+            event.accept(Items.ENCHANTED_MINER.get());
         }
     }
 }

--- a/src/main/resources/assets/bedrockores/blockstates/enchanted_bedrock_miner.json
+++ b/src/main/resources/assets/bedrockores/blockstates/enchanted_bedrock_miner.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "bedrockores:block/bedrock_miner" }
+  }
+}

--- a/src/main/resources/assets/bedrockores/lang/de_de.json
+++ b/src/main/resources/assets/bedrockores/lang/de_de.json
@@ -1,7 +1,9 @@
 {
   "block.bedrockores.bedrock_miner": "Grundgesteinbohrer",
+  "block.bedrockores.enchanted_bedrock_miner": "Verzauberter Bohrer",
   "gui.bedrockores.expected_yield": "Erwartete Ausbeute: %s",
   "gui.bedrockores.exhausted": "Erschöpft",
   "gui.bedrockores.infinite": "Unendlich",
-  "tooltip.bedrockores.bedrock_miner": "Gräbt Grundgesteinerze in einem Bereich von %sx%sx%s unter sich aus."
+  "tooltip.bedrockores.bedrock_miner": "Gräbt Grundgesteinerze in einem Bereich von %sx%sx%s unter sich aus.",
+  "tooltip.bedrockores.enchanted_bedrock_miner": "Kann mit Glück und Effizienz bis Stufe 10 verzaubert werden"
 }

--- a/src/main/resources/assets/bedrockores/lang/en_us.json
+++ b/src/main/resources/assets/bedrockores/lang/en_us.json
@@ -1,7 +1,9 @@
 {
   "block.bedrockores.bedrock_miner": "Bedrock Miner",
+  "block.bedrockores.enchanted_bedrock_miner": "Enchanted Miner",
   "gui.bedrockores.expected_yield": "Expected yield: %s",
   "gui.bedrockores.exhausted": "Exhausted",
   "gui.bedrockores.infinite": "Infinite",
-  "tooltip.bedrockores.bedrock_miner": "Mines the %sx%sx%s area below it for bedrock ores."
+  "tooltip.bedrockores.bedrock_miner": "Mines the %sx%sx%s area below it for bedrock ores.",
+  "tooltip.bedrockores.enchanted_bedrock_miner": "Functions like the miner but drops resources and supports Fortune and Efficiency enchantments."
 }

--- a/src/main/resources/assets/bedrockores/lang/it_it.json
+++ b/src/main/resources/assets/bedrockores/lang/it_it.json
@@ -1,7 +1,9 @@
 {
   "block.bedrockores.bedrock_miner": "Minatore di Roccia di Fondo",
+  "block.bedrockores.enchanted_bedrock_miner": "Minatore Incantato",
   "gui.bedrockores.expected_yield": "Rendimento atteso: %s",
   "gui.bedrockores.exhausted": "Esausto",
   "gui.bedrockores.infinite": "Infinito",
-  "tooltip.bedrockores.bedrock_miner": "Scava l'area del %sx%sx%s sotto di lui per minerali di roccia di fondo."
+  "tooltip.bedrockores.bedrock_miner": "Scava l'area del %sx%sx%s sotto di lui per minerali di roccia di fondo.",
+  "tooltip.bedrockores.enchanted_bedrock_miner": "Può essere incantato con Fortuna ed Efficienza fino al livello 10"
 }

--- a/src/main/resources/assets/bedrockores/lang/zh_cn.json
+++ b/src/main/resources/assets/bedrockores/lang/zh_cn.json
@@ -1,7 +1,9 @@
 {
   "block.bedrockores.bedrock_miner": "基岩矿石采掘机",
+  "block.bedrockores.enchanted_bedrock_miner": "附魔基岩采掘机",
   "gui.bedrockores.expected_yield": "预计产量：%s",
   "gui.bedrockores.exhausted": "采空",
   "gui.bedrockores.infinite": "无限",
-  "tooltip.bedrockores.bedrock_miner": "采集其 %sx%sx%s 范围下方所有基岩矿石内的矿物。"
+  "tooltip.bedrockores.bedrock_miner": "采集其 %sx%sx%s 范围下方所有基岩矿石内的矿物。",
+  "tooltip.bedrockores.enchanted_bedrock_miner": "可附魔时运与效率，掉落与玩家挖掘一致"
 }

--- a/src/main/resources/assets/bedrockores/models/block/enchanted_bedrock_miner.json
+++ b/src/main/resources/assets/bedrockores/models/block/enchanted_bedrock_miner.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bedrockores:block/bedrock_miner"
+}

--- a/src/main/resources/assets/bedrockores/models/item/enchanted_bedrock_miner.json
+++ b/src/main/resources/assets/bedrockores/models/item/enchanted_bedrock_miner.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bedrockores:block/bedrock_miner"
+}

--- a/src/main/resources/data/bedrockores/loot_tables/blocks/enchanted_bedrock_miner.json
+++ b/src/main/resources/data/bedrockores/loot_tables/blocks/enchanted_bedrock_miner.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "bedrockores:enchanted_bedrock_miner"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/resources/data/bedrockores/recipes/enchanted_bedrock_miner.json
+++ b/src/main/resources/data/bedrockores/recipes/enchanted_bedrock_miner.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "M": { "item": "bedrockores:bedrock_miner" },
+    "B": { "item": "minecraft:enchanting_table" }
+  },
+  "pattern": [
+    " B ",
+    " M ",
+    " B "
+  ],
+  "result": {
+    "item": "bedrockores:enchanted_bedrock_miner"
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `EnchantedMinerBlock` and block entity that mines like a player
- allow Fortune & Efficiency enchantments, scaling loot and mining area
- register new block, item and block entity
- reuse existing Bedrock Miner textures for new block
- add recipes, loot tables and translations
- upload artifacts from build workflow and fix build script

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6871fdb9ef98832099847c4a430aca5f